### PR TITLE
generate.js: Make org name clickable to GCI organization page

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -47,7 +47,7 @@ const template = `
     <div class="orgs">
       {{#orgs}}
         <div class="org">
-          <h3>{{name}}</h3>
+          <h3><a href="https://codein.withgoogle.com/organizations/{{slug}}">{{name}}</a></h3>
           <ul>
             {{#leaders}}
               <li>{{display_name}}</li>

--- a/scrap.js
+++ b/scrap.js
@@ -31,11 +31,5 @@ async function fetchOrgsWithLeaders() {
 
 ;(async () => {
   const data = await fetchOrgsWithLeaders()
-  
-  // sort data by completed_task_instance_count
-  data.sort((a, b) => 
-    b.completed_task_instance_count - a.completed_task_instance_count
-  )
-
   fs.writeFileSync('out/data.json', JSON.stringify(data))
 })()

--- a/scrap.js
+++ b/scrap.js
@@ -31,5 +31,11 @@ async function fetchOrgsWithLeaders() {
 
 ;(async () => {
   const data = await fetchOrgsWithLeaders()
+  
+  // sort data by completed_task_instance_count
+  data.sort((a, b) => 
+    b.completed_task_instance_count - a.completed_task_instance_count
+  )
+
   fs.writeFileSync('out/data.json', JSON.stringify(data))
 })()


### PR DESCRIPTION
Fixes https://github.com/coala/gci-leaders/issues/3