### PR TITLE
Find GitHub org for each GCI org

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -47,8 +47,15 @@ const template = `
     <div class="orgs">
       {{#orgs}}
         <div class="org">
-          <h3><a href="https://codein.withgoogle.com/organizations/{{slug}}">{{name}}</a></h3>
-          <p>Task Completed: {{completed_task_instance_count}}</p>
+          <h3>
+            <a href="https://codein.withgoogle.com/organizations/{{slug}}">{{name}}</a>
+            <p>Task Completed: {{completed_task_instance_count}}</p>
+            {{#github}}
+            <a href="https://github.com/{{github}}">
+              <img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" height="14" />
+            </a>
+            {{/github}}
+          </h3>
           <ul>
             {{#leaders}}
               <li>{{display_name}}</li>

--- a/scrap.js
+++ b/scrap.js
@@ -1,6 +1,10 @@
 const fetch = require('node-fetch')
 const fs = require('fs')
 
+const GITHUB_API_BASE = 'https://api.github.com'
+
+const MIN_SEARCH_SCORE = 10
+
 async function fetchOrgs() {
   const res = await fetch(
     'https://codein.withgoogle.com/api/program/2017/organization/?status=2'
@@ -17,20 +21,82 @@ async function fetchLeaders(id) {
   return leaders
 }
 
-async function fetchOrgsWithLeaders() {
+async function searchGitHubOrgs(query) {
+  const token = process.env.GITHUB_TOKEN
+  const res = await fetch(
+    `${GITHUB_API_BASE}/search/users?q=${query}%20type:org`,
+    {
+      headers: token ? { Authorization: `token ${token}` } : {}
+    }
+  )
+  const { items } = await res.json()
+  return items || []
+}
+
+async function findOrganization({
+  name,
+  description,
+  mailing_list,
+  website_url,
+  irc_channel,
+  blog_url,
+  guide_to_working_url,
+}) {
+  const ghPattern = /(?:https?:\/\/)?(?:github\.com|gitter\.im)\/([a-zA-Z0-9-]+)/i
+  const websites = [
+    mailing_list,
+    website_url,
+    irc_channel,
+    blog_url,
+    guide_to_working_url,
+  ]
+
+  const orgFromWebsites = websites
+    .map(website => (ghPattern.exec(website) || [])[1])
+    .find(org => org)
+
+  if (orgFromWebsites) {
+    return orgFromWebsites
+  }
+
+  const orgFromDescription = (ghPattern.exec(description) || [])[1]
+
+  if (orgFromDescription) {
+    return orgFromDescription
+  }
+
+  console.warn(
+    `Could not find GitHub org for ${name}. Resorting to GitHub API hit.`
+  )
+
+  const removePattern = /the|project|\([a-zA-Z]+\)/gi
+  const searchQuery = name.replace(removePattern, '').trim()
+  const searchResults = await searchGitHubOrgs(searchQuery)
+
+  if (searchResults.length > 0 && searchResults[0].score > MIN_SEARCH_SCORE) {
+    return searchResults[0].login
+  }
+
+  return null
+}
+
+async function fetchOrgsWithData() {
   const orgs = await fetchOrgs()
   const fetchingLeaders = orgs.map(org => fetchLeaders(org.id))
+  const fetchingGitHub = orgs.map(org => findOrganization(org))
   const orgLeaders = await Promise.all(fetchingLeaders)
+  const orgGitHub = await Promise.all(fetchingGitHub)
 
   return orgs.map((org, index) =>
     Object.assign(org, {
       leaders: orgLeaders[index],
+      github: orgGitHub[index],
     })
   )
 }
 
 ;(async () => {
-  const data = await fetchOrgsWithLeaders()
+  const data = await fetchOrgsWithData()
   
   // sort data by completed_task_instance_count
   data.sort((a, b) => 


### PR DESCRIPTION
This will add the ability to find the GitHub organization of a GCI
org by looking in different links and the description, and then
searching GitHub if the previous search was unsuccessful.

Closes https://github.com/coala/gci-leaders/issues/7

## Logic

_(first successful step will be considered the organization's GitHub org)_

- ~~Check if overridden~~
- RegEx check for `https://github.com/(orgname)` or `https://gitter.im/(orgname)` in one of org URLs 
- RegEx check for `https://github.com/(orgname)` in org description
- GitHub search for org name (must have >10 score)
- `null`

## Accuracy

`100%`

All organizations' GitHub accounts were successfully found. 10 are found in the GCI org, and the other 15 are found through a GitHub API call.

## Screenshot

![screen shot 2017-12-04 at 11 58 01 pm](https://user-images.githubusercontent.com/10191084/33596378-5af051a0-d950-11e7-8143-4a51b5c194df.png)
