### PR TITLE
generate.js: Display completed task number

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -43,11 +43,12 @@ const template = `
   </head>
   <body>
     <h1>GCI Current Leaders</h1>
-    <i>Names are listed alphabetically</i>
+    <i>The leading participants for each organization are listed alphabetically according to their "display name"</i>
     <div class="orgs">
       {{#orgs}}
         <div class="org">
           <h3><a href="https://codein.withgoogle.com/organizations/{{slug}}">{{name}}</a></h3>
+          <p>Task Completed: {{completed_task_instance_count}}</p>
           <ul>
             {{#leaders}}
               <li>{{display_name}}</li>


### PR DESCRIPTION
Display the number of tasks completed for each org and fix listed info

Closes https://github.com/coala/gci-leaders/issues/16