### PR TITLE
Separate HTML and CSS into their own files

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -19,6 +19,15 @@ bears = LineLengthBear
 [all.links]
 bears = InvalidLinkBear
 
+[css]
+files = static/css/*.css
+bears = CSSLintBear
+
+[html]
+files = templates/*.html
+bears = HTMLLintBear
+htmllint_ignore = optional
+
 [json]
 files = *.json
 ignore = package-lock.json

--- a/generate.js
+++ b/generate.js
@@ -1,85 +1,15 @@
 const fs = require('fs')
 const Mustache = require('mustache')
+const ncp = require('ncp').ncp
 const orgs = require('./out/data.json')
 
-const githubImage =
-  'https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png'
+ncp('static', 'out/static', err => {
+  if (err) {
+    console.error(err)
+  }
+})
 
-const template = `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>GCI Leaders</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <style>
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
-          Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-          "Segoe UI Symbol";
-        line-height: 1.5;
-        max-width: 800px;
-        margin: 0 auto;
-        padding: 0 1em;
-      }
-
-      h1 {
-        margin: .5em 0 0 0;
-      }
-
-      .orgs {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-around;
-      }
-
-      .org {
-        flex: 0 0 25%;
-        margin-bottom: 1em;
-      }
-
-      ul {
-        padding-left: 1em;
-        margin: 0;
-      }
-    </style>
-  </head>
-  <body>
-    <h1>GCI Current Leaders</h1>
-    <i>
-      The leading participants for each organization are listed alphabetically
-      according to their "display name"
-    </i>
-    <div class="orgs">
-      {{#orgs}}
-        <div class="org">
-          <h3>
-            <a href="https://codein.withgoogle.com/organizations/{{slug}}">
-              {{name}}
-            </a>
-            <p>Task Completed: {{completed_task_instance_count}}</p>
-            {{#github}}
-            <a href="https://github.com/{{github}}">
-              <img
-                src="${githubImage}"
-                height="18"
-              />
-            </a>
-            {{/github}}
-          </h3>
-          <ul>
-            {{#leaders}}
-              <li>{{display_name}}</li>
-            {{/leaders}}
-            {{^leaders}}
-              <li style="color: gray;">None</li>
-            {{/leaders}}
-          </ul>
-        </div>
-      {{/orgs}}
-    </div>
-  </body>
-</html>
-`
-
-fs.writeFileSync('out/index.html', Mustache.render(template, { orgs }))
+fs.writeFileSync(
+  'out/index.html',
+  Mustache.render(fs.readFileSync('templates/main.html').toString(), { orgs })
+)

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "license": "MIT",
   "dependencies": {
     "mustache": "^2.3.0",
+    "ncp": "^2.0.0",
     "node-fetch": "^1.7.3"
   },
   "devDependencies": {
+    "csslint": "^1.0.5",
     "eslint": "^4.12.1",
     "eslint-plugin-prettier": "^2.3.1",
     "prettier": "^1.9.1"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,33 @@
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica,
+    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol";
+  line-height: 1.5;
+  margin: 0 auto;
+  max-width: 800px;
+  padding: 0 1em;
+}
+
+h1 {
+  margin: .5em 0 0 0;
+}
+
+.orgs {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+}
+
+.org {
+  flex: 0 0 25%;
+  margin-bottom: 1em;
+}
+
+.none {
+  color: gray;
+}
+
+ul {
+  margin: 0;
+  padding-left: 1em;
+}

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>GCI Leaders</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <link rel="stylesheet" href="static/css/main.css">
+  </head>
+  <body>
+    <h1>GCI Current Leaders</h1>
+    <i>
+      The leading participants for each organization are listed alphabetically
+      according to their "display name".
+    </i>
+    <div class="orgs">
+      {{#orgs}}
+        <div class="org">
+          <h3>
+            <a href="https://codein.withgoogle.com/organizations/{{slug}}">
+              {{name}}
+            </a>
+            <p>Task Completed: {{completed_task_instance_count}}</p>
+            {{#github}}
+            <a href="https://github.com/{{github}}">
+              <img
+                src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png"
+                height="18"
+              />
+            </a>
+            {{/github}}
+          </h3>
+          <ul>
+            {{#leaders}}
+              <li>{{display_name}}</li>
+            {{/leaders}}
+            {{^leaders}}
+              <li class="none">None</li>
+            {{/leaders}}
+          </ul>
+        </div>
+      {{/orgs}}
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This separates the HTML into a templates/ directory and the CSS
into a static/css/ directory.

Closes https://github.com/coala/gci-leaders/issues/21