### PR TITLE
css: Prevent organization names wrapping with images.

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -24,6 +24,7 @@ h1 {
 }
 
 .org-image {
+  display: block;
   width: 80%;
 }
 


### PR DESCRIPTION
On large screens, short words share the same line with organization images.

Fixes https://github.com/coala/gci-leaders/issues/47