### PR TITLE
Add timeline and countdown

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -2,10 +2,14 @@ const fs = require('fs')
 const Mustache = require('mustache')
 const ncp = require('ncp').ncp
 const orgs = require('../out/data.json')
+const dates = require('../out/dates.json')
 
 const time = fs.statSync(`${__dirname}/../out/data.json`).mtime
 const datetime = new Date(time).toUTCString()
 const rootURL = process.env.URL
+
+const competitionOpen = new Date(dates.competition_open_starts)
+const noClaims = new Date(dates.competition_open_ends)
 
 ncp('static', 'out/static', err => {
   if (err) {
@@ -26,5 +30,7 @@ fs.writeFileSync(
     datetime,
     rootURL,
     noLeader,
+    competitionOpen,
+    noClaims,
   })
 )

--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -113,8 +113,14 @@ async function fetchOrgsWithData() {
   )
 }
 
+async function fetchDates() {
+  const res = await fetch('https://codein.withgoogle.com/api/program/current/')
+  return res.json()
+}
+
 ;(async () => {
   const data = await fetchOrgsWithData()
+  const dates = await fetchDates()
 
   // sort data by completed_task_instance_count
   data.sort(
@@ -122,4 +128,5 @@ async function fetchOrgsWithData() {
   )
 
   fs.writeFileSync(`${__dirname}/../out/data.json`, JSON.stringify(data))
+  fs.writeFileSync(`${__dirname}/../out/dates.json`, JSON.stringify(dates))
 })()

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -85,3 +85,21 @@ footer {
     width: 100%;
   }
 }
+
+.progress-outer {
+  display: inline-block;
+  width: 100%;
+}
+
+.progress-inner {
+  background-color: #f5f5f5;
+}
+
+.progress-bar {
+  background-color: #1890ff;
+}
+
+.progress-text {
+  color: grey;
+  display: inline-block;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -35,3 +35,26 @@ allLeaders.forEach(function(orgList) {
     orgList.appendChild(orgList.children[(Math.random() * i) | 0])
   }
 })
+
+document.getElementById('progress').textContent = gciProgress()
+
+function gciProgress() {
+  const progress = document.getElementById('progress').dataset
+  const competitionOpen = new Date(progress.competitionopen)
+  const noClaims = new Date(progress.noclaims)
+  const current = new Date()
+  const percentagePassed =
+    100 - (noClaims - current) / (noClaims - competitionOpen) * 100
+  document
+    .getElementsByClassName('progress-bar')[0]
+    .setAttribute(
+      'style',
+      'width:' + percentagePassed + '%;height: 8px;border-radius: 100px;'
+    )
+  return (
+    Math.round(percentagePassed) +
+    '% passed, ' +
+    timeDifference(noClaims, current).slice(0, -4) +
+    ' before task claiming ends'
+  )
+}

--- a/templates/main.html
+++ b/templates/main.html
@@ -17,6 +17,15 @@
       <h1>Google Code-in 2017 Current Leaders</h1>
     </div>
     <small id="time" data-time="{{datetime}}">Last updated: {{datetime}} <span id="ago"></span></small>
+    <div>
+      <div class="progress-outer">
+        <div class="progress-inner">
+          <div class="progress-bar">
+          </div>
+        </div>
+      </div>
+      <span class="progress-text"><i id="progress" data-noclaims="{{noClaims}}" data-competitionopen="{{competitionOpen}}"></i></span>
+    </div>
     <hr>
     <i>
       The leading participants for each organization are listed randomly. 


### PR DESCRIPTION
This commit adds timeline with countdown.

Closes https://github.com/coala/gci-leaders/issues/51

- On computer 
<img width="917" alt="screen shot 2017-12-10 at 8 53 20 pm" src="https://user-images.githubusercontent.com/14857092/33805021-493c422a-ddec-11e7-871a-6f664eabf625.png">

- On mobile 
<img width="415" alt="screen shot 2017-12-10 at 8 53 31 pm" src="https://user-images.githubusercontent.com/14857092/33805022-496ff62e-ddec-11e7-8f6e-35c0d592eecd.png">
