### PR TITLE
Ignore Mac resource files and yarn.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 out/*
 !out/.keep
+yarn.lock
+.DS_Store


### PR DESCRIPTION
This prevents git displaying changes in `.DS_Store` and `yarn.lock`.