### PR TITLE
scrape.js: Reduce number of API calls

### DIFF
--- a/lib/gather.js
+++ b/lib/gather.js
@@ -1,0 +1,13 @@
+const fetch = require('node-fetch')
+const fs = require('fs')
+
+async function getData() {
+  const res = await fetch(
+    'https://raw.githubusercontent.com/coala/gci-leaders/gh-pages/data.min.json'
+  )
+
+  const data = await res.json()
+  fs.writeFileSync(`${__dirname}/../out/data.min.json`, JSON.stringify(data))
+}
+
+getData()

--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -39,6 +39,15 @@ const GH_WEB_OPTIONS = {
   compress: false,
 }
 
+let existingData = []
+try {
+  existingData = JSON.parse(
+    fs.readFileSync(`${__dirname}/../out/data.min.json`).toString()
+  )
+} catch (e) {
+  console.log('No existing data...')
+}
+
 async function fetchProgram() {
   const res = await fetch(`${GCI_API_BASE}/program/2017/`)
   return await res.json()
@@ -209,12 +218,12 @@ async function findWiki(name) {
   }
 }
 
-async function findGitHubUser({ display_name }, org) {
+async function findGitHubUser(displayName, org) {
   if (!org) return
 
-  const shortName = validUsername(display_name)
+  const shortName = validUsername(displayName)
 
-  const username = await findGitHubUserInOrg(display_name, org)
+  const username = await findGitHubUserInOrg(displayName, org)
   if (username) return username
 
   const displayNamePattern = /^[a-zA-Z0-9-]{1,39}$/
@@ -259,18 +268,40 @@ async function findGitHubUserInOrg(user, org) {
 async function fetchOrgsWithData() {
   const orgs = await fetchOrgs()
   const fetchingLeaders = orgs.map(org => fetchLeaders(org.id))
-  const fetchingGitHub = orgs.map(org => findOrganization(org))
-  const fetchingChat = orgs.map(org => chattie(org.irc_channel))
-  const fetchingWiki = orgs.map(org => findWiki(org.name))
+  const fetchingGitHub = orgs.map(org => {
+    const existingOrg = existingData.find(existing => existing.id === org.id)
+    if (existingOrg && existingOrg.github) return existingOrg.github
+    else return findOrganization(org)
+  })
+  const fetchingChat = orgs.map(org => {
+    const existingOrg = existingData.find(existing => existing.id === org.id)
+    if (existingOrg && existingOrg.chat) return existingOrg.chat
+    else return chattie(org.irc_channel)
+  })
+  const fetchingWiki = orgs.map(org => {
+    const existingOrg = existingData.find(existing => existing.id === org.id)
+    if (existingOrg && existingOrg.wiki) return existingOrg.wiki
+    else return findWiki(org.name)
+  })
   const orgLeaders = await Promise.all(fetchingLeaders)
   const orgGitHub = await Promise.all(fetchingGitHub)
   const orgChats = await Promise.all(fetchingChat)
   const orgWiki = await Promise.all(fetchingWiki)
 
   const fetchingAll = orgs.map(async (org, index) => {
-    const fetchingUsers = orgLeaders[index].map(user =>
-      findGitHubUser(user, orgGitHub[index])
-    )
+    const existingOrg = existingData.find(existing => existing.id === org.id)
+    const fetchingUsers = orgLeaders[index].map(user => {
+      if (existingOrg && existingOrg.leaders) {
+        const existingUser = existingOrg.leaders.find(
+          leader => leader.id === user.id
+        )
+        if (existingUser && existingUser.github_account) {
+          return existingUser.github_account
+        }
+      }
+
+      return findGitHubUser(user.display_name, orgGitHub[index])
+    })
     const orgUsers = await Promise.all(fetchingUsers)
 
     const leaders = orgLeaders[index].map((user, index) =>
@@ -284,8 +315,12 @@ async function fetchOrgsWithData() {
       github: orgGitHub[index],
       chat: {
         url: orgChats[index].url,
-        platform: chattie.CHAT[orgChats[index].type],
-        image: CHAT_IMAGES[chattie.CHAT[orgChats[index].type]],
+        platform: orgChats[index].platform
+          ? orgChats[index].platform
+          : chattie.CHAT[orgChats[index].type],
+        image: orgChats[index].image
+          ? orgChats[index].image
+          : CHAT_IMAGES[chattie.CHAT[orgChats[index].type]],
       },
       wiki: {
         wikipedia: orgWiki[index].wikipedia,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
     "acorn": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
+      "integrity": "sha1-MXrHghgmwixwLWYYmrg1lnXxNdc=",
       "dev": true
     },
     "acorn-jsx": {
@@ -63,7 +63,7 @@
     "ansi-escapes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-      "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+      "integrity": "sha1-7D6LTp+AZPwCw6ybZfHCdb2o75I=",
       "dev": true
     },
     "ansi-regex": {
@@ -325,7 +325,7 @@
     "chalk": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-      "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+      "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
@@ -336,7 +336,7 @@
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
@@ -371,7 +371,7 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
       "dev": true
     },
     "cli-cursor": {
@@ -461,7 +461,7 @@
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -699,7 +699,7 @@
     "debug": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -740,7 +740,7 @@
     "doctrine": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.2.tgz",
-      "integrity": "sha512-y0tm5Pq6ywp3qSTZ1vPgVdAnbDEoeoc5wlOHXoY1c4Wug/a7JvqHIl7BTvwodaHmejWkK/9dSb3sCYfyo/om8A==",
+      "integrity": "sha1-aPls6O/FbMQmUfH6rbTxdSc7AHU=",
       "dev": true,
       "requires": {
         "esutils": "2.0.2"
@@ -957,7 +957,7 @@
     "eslint-plugin-prettier": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz",
-      "integrity": "sha1-56dGxn5xbzNSdLiClanq2fVE5E0=",
+      "integrity": "sha512-AV8shBlGN9tRZffj5v/f4uiQWlP3qiQ+lh+BhTqRLuKSyczx+HRWVkVZaf7dOmguxghAH1wftnou/JUEEChhGg==",
       "dev": true,
       "requires": {
         "fast-diff": "1.1.2",
@@ -977,7 +977,7 @@
     "espree": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-      "integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+      "integrity": "sha1-dWrai5eenc/NswqtjRqTBKkF4co=",
       "dev": true,
       "requires": {
         "acorn": "5.2.1",
@@ -987,7 +987,7 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
       "dev": true
     },
     "esquery": {
@@ -1056,7 +1056,7 @@
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
-      "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+      "integrity": "sha1-PQJqIbf5W1cmOH1CAKwWDTcsO0g=",
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
@@ -1086,7 +1086,7 @@
     "fast-diff": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha1-S2LEK44D3j+EhGC2OQeZIGldAVQ=",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1231,7 +1231,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -1368,7 +1368,7 @@
     "ignore": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "integrity": "sha1-YSKJv7PCIOGGpYEYYY1b6MG6sCE=",
       "dev": true
     },
     "imurmurhash": {
@@ -1411,7 +1411,7 @@
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+      "integrity": "sha1-ndLyrXZdyrH/BEO0kUQqILoifck=",
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
@@ -1637,7 +1637,7 @@
     "jest-docblock": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha1-UVKcOzDV/RWdpgwnzu3Blfr41BQ=",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
       "dev": true
     },
     "js-base64": {
@@ -1655,7 +1655,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1842,7 +1842,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
@@ -1930,7 +1930,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
@@ -2232,7 +2232,7 @@
     "pluralize": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "integrity": "sha1-KYuJ34uTsCIdv0Ia0rGx6iP8Z3c=",
       "dev": true
     },
     "postcss": {
@@ -2497,7 +2497,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
@@ -2643,7 +2643,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2681,7 +2681,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4=",
       "dev": true
     },
     "shebang-command": {
@@ -2708,7 +2708,7 @@
     "slice-ansi": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+      "integrity": "sha1-BE8aSdiEL/MHqta1Be0Xi9lQE00=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0"
@@ -2803,7 +2803,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
@@ -2813,7 +2813,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -3056,7 +3056,7 @@
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "integrity": "sha1-ozRHN1OR52atNNNIbm4q7chNLjY=",
       "dev": true,
       "requires": {
         "ajv": "5.5.1",
@@ -3118,7 +3118,7 @@
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
         "os-tmpdir": "1.0.2"
@@ -3218,7 +3218,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "node ./lib/scrape.js && node ./lib/generate.js"
+    "scrape": "node ./lib/scrape.js",
+    "generate": "node ./lib/generate.js",
+    "gather": "node ./lib/gather.js",
+    "clean": "rm -rf out/*",
+    "build": "npm run gather && npm run scrape && npm run generate",
+    "build:clean": "npm run clean && npm run scrape && npm run generate"
   },
   "keywords": [],
   "author": "blazeu <neversleepman@tfwno.gf>",


### PR DESCRIPTION
Once we get search results from GitHub, be it an organization account
or a student account, we know it will almost certainly stay constant.
This will use the data from previous builds as a base to build off of
for future builds. Once we get data for a certain organization or
user, that data won't be searched for again.

Closes https://github.com/coala/gci-leaders/issues/27