### PR TITLE
scraper.js: Wiki fixes

### DIFF
--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -278,11 +278,7 @@ async function fetchOrgsWithData() {
     if (existingOrg && existingOrg.chat) return existingOrg.chat
     else return chattie(org.irc_channel)
   })
-  const fetchingWiki = orgs.map(org => {
-    const existingOrg = existingData.find(existing => existing.id === org.id)
-    if (existingOrg && existingOrg.wiki) return existingOrg.wiki
-    else return findWiki(org.name)
-  })
+  const fetchingWiki = orgs.map(org => findWiki(org.name))
   const orgLeaders = await Promise.all(fetchingLeaders)
   const orgGitHub = await Promise.all(fetchingGitHub)
   const orgChats = await Promise.all(fetchingChat)
@@ -322,10 +318,8 @@ async function fetchOrgsWithData() {
           ? orgChats[index].image
           : CHAT_IMAGES[chattie.CHAT[orgChats[index].type]],
       },
-      wiki: {
-        wikipedia: orgWiki[index].wikipedia,
-        wikidata: orgWiki[index].wikidata,
-      },
+      wikipedia_urls: orgWiki[index].wikipedia,
+      wikidata_url: orgWiki[index].wikidata,
     })
   })
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -79,16 +79,16 @@
                 <img src="static/images/logos/global.png" class="chat" />
               </a>
             {{/website_url}}
-            {{#wiki.wikipedia.en}}
-              <a href="{{wiki.wikipedia.en}}">
+            {{#wikipedia_urls.en}}
+              <a href="{{wikipedia_urls.en}}">
                 <img src="static/images/logos/wikipedia.png" class="chat" />
               </a>
-            {{/wiki.wikipedia.en}}
-            {{#wiki.wikidata}}
-              <a href="{{wiki.wikidata}}">
+            {{/wikipedia_urls.en}}
+            {{#wikidata_url}}
+              <a href="{{wikidata_url}}">
                 <img src="static/images/logos/wikidata.png" class="chat" />
               </a>
-            {{/wiki.wikidata}}
+            {{/wikidata_url}}
             <div class="org-leaderboard">
               <ul>
                 {{#leaders}}
@@ -159,16 +159,16 @@
                 <img src="static/images/logos/global.png" class="chat" />
               </a>
             {{/website_url}}
-            {{#wiki.wikipedia.en}}
-              <a href="{{wiki.wikipedia.en}}">
+            {{#wikipedia_urls.en}}
+              <a href="{{wikipedia_urls.en}}">
                 <img src="static/images/logos/wikipedia.png" class="chat" />
               </a>
-            {{/wiki.wikipedia.en}}
-            {{#wiki.wikidata}}
-              <a href="{{wiki.wikidata}}">
+            {{/wikipedia_urls.en}}
+            {{#wikidata_url}}
+              <a href="{{wikidata_url}}">
                 <img src="static/images/logos/wikidata.png" class="chat" />
               </a>
-            {{/wiki.wikidata}}
+            {{/wikidata_url}}
           </div>
         </div>
         {{/noLeader}}


### PR DESCRIPTION
Stops caching wikidata/wikipedia links.
Unloads the urls into top level instead of storing inside "wiki".

Closes https://github.com/coala/gci-leaders/issues/82
Related to #81 and #79 