### PR TITLE
scrape.js: Handle username changes and deletions

### DIFF
--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -5,12 +5,16 @@ const json2yaml = require('json2yaml')
 const validUsername = require('valid-github-username')
 const wdk = require('wikidata-sdk')
 
-const GH_USER_BASE = 'https://github.com/users'
-const GH_ORG_BASE = 'https://github.com/orgs'
+const GH_BASE = 'https://github.com'
+const GH_USER_BASE = `${GH_BASE}/users`
+const GH_ORG_BASE = `${GH_BASE}/orgs`
 const GH_API_BASE = 'https://api.github.com'
 const GCI_API_BASE = 'https://codein.withgoogle.com/api'
 
 const MIN_SEARCH_SCORE = 10
+
+// The time to cache GitHub usernames for in milliseconds
+const GITHUB_CACHE_TIME = 7 * 24 * 60 * 60 * 1000
 
 const CHAT_IMAGES = {
   GITTER: 'images/logos/gitter.png',
@@ -63,6 +67,11 @@ async function fetchLeaders(id) {
   const res = await fetch(`${GCI_API_BASE}/program/current/organization/${id}`)
   const { leaders } = await res.json()
   return leaders
+}
+
+async function checkGitHubUserExists(user) {
+  const res = await fetch(`${GH_BASE}/${user}`)
+  return res.status === 200
 }
 
 async function searchGitHubOrgs(query) {
@@ -260,6 +269,42 @@ async function findGitHubUserInOrg(user, org) {
   return match ? match[1] : null
 }
 
+function checkGitHubUserCacheExpired(user) {
+  if (user && user.github_updated) {
+    return Date.now() - user.github_updated > GITHUB_CACHE_TIME
+  }
+}
+
+async function freshenUserGitHubCache(user, existingUser, organization) {
+  if (!existingUser) {
+    return {
+      login: await findGitHubUser(user.display_name, organization),
+      updated: Date.now(),
+    }
+  }
+
+  if (checkGitHubUserCacheExpired(existingUser)) {
+    const exists = await checkGitHubUserExists(user.github_account)
+
+    if (exists) {
+      return {
+        login: existingUser.github_account,
+        updated: Date.now(),
+      }
+    } else {
+      return {
+        login: await findGitHubUser(user.display_name, organization),
+        updated: Date.now(),
+      }
+    }
+  } else {
+    return {
+      login: existingUser.github_account,
+      updated: existingUser.github_updated,
+    }
+  }
+}
+
 async function fetchOrgsWithData() {
   const orgs = await fetchOrgs()
   const fetchingLeaders = orgs.map(org => fetchLeaders(org.id))
@@ -281,25 +326,22 @@ async function fetchOrgsWithData() {
 
   const fetchingAll = orgs.map(async (org, index) => {
     const existingOrg = existingData.find(existing => existing.id === org.id)
-    const fetchingUsers = orgLeaders[index].map(user => {
+    const fetchingUsers = orgLeaders[index].map(async user => {
+      let existingUser
       if (existingOrg && existingOrg.leaders) {
-        const existingUser = existingOrg.leaders.find(
-          leader => leader.id === user.id
-        )
-        if (existingUser && existingUser.github_account) {
-          return existingUser.github_account
-        }
+        existingUser = existingOrg.leaders.find(leader => leader.id === user.id)
       }
 
-      return findGitHubUser(user.display_name, orgGitHub[index])
+      return await freshenUserGitHubCache(user, existingUser, orgGitHub[index])
     })
     const orgUsers = await Promise.all(fetchingUsers)
 
-    const leaders = orgLeaders[index].map((user, index) =>
-      Object.assign(user, {
-        github_account: orgUsers[index],
+    const leaders = orgLeaders[index].map((user, index) => {
+      return Object.assign(user, {
+        github_account: orgUsers[index] ? orgUsers[index].login : null,
+        github_updated: orgUsers[index] ? orgUsers[index].updated : null,
       })
-    )
+    })
 
     return Object.assign(org, {
       leaders: leaders,


### PR DESCRIPTION
Prior to this, if a user's GitHub account was cached, it would be
assumed to be correct for all future builds. However, this is not
the case if the user has changed or deleted their account. This
will verify that the cached username exists before using it, and
rerun the username finding code if it does not exist.

Closes https://github.com/coala/gci-leaders/issues/93