### PR TITLE
Add banner to deploy previews

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const Mustache = require('mustache')
 const mapKeys = require('lodash.mapkeys')
+const netlifyEnv = require('netlify-env')
+
 const orgs = require('../out/data.json')
 const dates = require('../out/dates.json')
 const planet = require('../out/blog_planet.json')
@@ -37,6 +39,7 @@ fs.writeFileSync(
     competitionOpen,
     noClaims,
     assets,
+    ...netlifyEnv,
   })
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5919,6 +5919,11 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
+    "netlify-env": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/netlify-env/-/netlify-env-0.0.4.tgz",
+      "integrity": "sha512-Vo3MbBQf9qBybhjKGc66xlj2zqgpllarQp3XOk/Gn1D4YHVhVqglIEX858JeRQkEXwRn9dVJ32AG+LI/DcouKQ=="
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "json2yaml": "^1.1.0",
     "lodash.mapkeys": "^4.6.0",
     "mustache": "^2.3.0",
+    "netlify-env": "^0.0.4",
     "node-fetch": "^1.7.3",
     "rss": "^1.2.2",
     "sort-keys": "^2.0.0",

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12,6 +12,7 @@ body {
   line-height: 1.5;
   margin: 0 auto;
   max-width: 800px;
+  overflow-x: hidden;
   padding: 0 1em;
 }
 
@@ -127,4 +128,21 @@ footer {
 
 .chooser {
   margin-top: 0.5em;
+}
+
+.preview {
+  background-color: crimson;
+  color: white;
+  padding: 10px 0;
+  text-align: center;
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;
+  margin-right: -50vw;
+}
+
+.preview > a {
+  color: aqua;
 }

--- a/templates/main.html
+++ b/templates/main.html
@@ -10,6 +10,11 @@
     <link rel="stylesheet" href="{{assets.main-css}}">
   </head>
   <body>
+    {{#DEPLOY_PREVIEW}}
+      <div class="preview">
+        This is a Deploy Preview of <a href="{{DEPLOY_PREVIEW_PR_URL}}">PR #{{DEPLOY_PREVIEW_PR_NUMBER}}</a>. See the production website <a href="{{URL}}">here</a>.
+      </div>
+    {{/DEPLOY_PREVIEW}}
     <div>
       <a href="http://codein.withgoogle.com">
         <img class="gci-logo" src="images/logos/gci.png" alt="Code-In logo">


### PR DESCRIPTION
This adds banners to the top of the page on Netlify Deploy Previews
with a link to the PR and the production deploy.

Closes https://github.com/coala/gci-leaders/issues/89