### PR TITLE
Fixing https://github.com/coala/gci-leaders/issues/116

### DIFF
--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -203,7 +203,6 @@ async function getGitHubUserHistory(user, from, to) {
   const actions = [
     'created_commits',
     'created_issues',
-    'created_issues',
     'created_pull_requests',
     'created_pull_request_reviews',
   ]


### PR DESCRIPTION
The created_issues were called twice unnecessarily. This commit deleted one to remove duplicated call.
This PR Fixes : https://github.com/coala/gci-leaders/issues/116