### PR TITLE
Use current for lastest data

### DIFF
--- a/lib/scrape.js
+++ b/lib/scrape.js
@@ -97,13 +97,16 @@ try {
 }
 
 async function fetchProgram() {
-  const res = await fetch(`${GCI_API_BASE}/program/2017/`)
+  const res = await fetch(`${GCI_API_BASE}/program/current/`)
   return await res.json()
 }
 
 async function fetchOrgs() {
-  const res = await fetch(`${GCI_API_BASE}/program/2017/organization/?status=2`)
+  const res = await fetch(
+    `${GCI_API_BASE}/program/current/organization/?status=2`
+  )
   const { results } = await res.json()
+
   return results
 }
 


### PR DESCRIPTION
Instead of monkeying around dynamic year, just use current in api from
google