### PR TITLE
Add Strings Replacing GCI 2018  with GCI 2019

### DIFF
--- a/static/i18n/en.json
+++ b/static/i18n/en.json
@@ -1,5 +1,5 @@
 {
-    "page-title": "Google Code-in 2018 Current Leaders",
+    "page-title": "Google Code-in 2019 Current Leaders",
     "last-updated": "Last updated",
     "order-info": "The leading participants for each organization (and their GitHub accounts, if applicable) are listed randomly.",
     "tasks-completed": "Tasks Completed",

--- a/static/i18n/es.json
+++ b/static/i18n/es.json
@@ -1,5 +1,5 @@
 {
-    "page-title": "Líderes actuales de Google Code-in 2018",
+    "page-title": "Líderes actuales de Google Code-in 2019",
     "last-updated": "Última actualización",
     "order-info": "Los participantes líderes de cada organización (y sus respectivas cuentas de GitHub) están listados de forma aleatoria.",
     "tasks-completed": "Tareas completadas",

--- a/static/i18n/pl.json
+++ b/static/i18n/pl.json
@@ -1,5 +1,5 @@
 {
-    "page-title": "Obecni liderzy Google Code-in 2018",
+    "page-title": "Obecni liderzy Google Code-in 2019",
     "last-updated": "Ostatnio aktualizowano",
     "order-info": "Uczestnicy na prowadzeniu z każdej organizacji (i ich konta na GitHubie, jeśli dotyczy) wypisani są w kolejności losowej.",
     "tasks-completed": "Ukończone zadania",


### PR DESCRIPTION
Website says Google Code-in 2018 Leaders but Google Code-in 2018 ended and now it's Google Code-in 2019